### PR TITLE
Fixed html-minifier overwrites source files and outputs empty files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All parameters are optional. Don't put them in your *wercker.yml* to use the def
 
 * `base_dir`: The directory containing the website to be minified. *Default is `public`.*
 * `threads`: The number of simultaneous operations. Put this between quotes (e.g. *"4"*). *Default is the number of cores of the host.*
-* `html_args`: The arguments for [html-minifier](https://github.com/kangax/html-minifier). *Default is `--use-short-doctype --remove-style-link-type-attributes --remove-script-type-attributes --remove-comments --minify-css --minify-js --collapse-whitespace --remove-comments-from-cdata --conservative-collapse --remove-cdatasections-from-cdata`.*
+* `html_args`: The arguments for [html-minifier](https://github.com/kangax/html-minifier). *Default is `--use-short-doctype --remove-style-link-type-attributes --remove-script-type-attributes --remove-comments --minify-css --minify-js --collapse-whitespace --conservative-collapse`.*
 * `png_args`: The arguments for [optipng](http://optipng.sourceforge.net/). *Default is `-o7 -f4 -strip all`.*
 * `yui_args`: The arguments for [yuicompressor](https://github.com/yui/yuicompressor). *No arguments by default.*
 * `html`: Set this to `false` to disable HTML minification. *Default is `true`.*

--- a/run.sh
+++ b/run.sh
@@ -182,7 +182,7 @@ verify_node()
         # install node
         echo "node not installed, installing..."
         if command_exists apt-get; then
-    		curl -sL https://deb.nodesource.com/setup_0.12 | bash -
+            curl -sL https://deb.nodesource.com/setup_6.x | bash -
             apt-get install -y nodejs build-essential
         elif command_exists pacman; then
             pacman -S --noconfirm nodejs npm

--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ update_sources()
             pacman -Syu
         fi
         SOURCES_UPDATED=true
-    fi 
+    fi
 }
 
 set_variables()
@@ -55,13 +55,13 @@ set_variables()
         WERCKER_MINIFY_THREADS=$CORES
     fi
     echo "running with $WERCKER_MINIFY_THREADS threads"
-    
+
     # set base directory to public if not set
     DEFAULTDIR="public"
     if [ ! -n "$WERCKER_MINIFY_BASE_DIR" ]; then
         WERCKER_MINIFY_BASE_DIR=$DEFAULTDIR
     fi
-    
+
     # set minify defaults
     if [ ! -n "$WERCKER_MINIFY_HTML" ]; then
         WERCKER_MINIFY_HTML=true
@@ -112,15 +112,15 @@ minify_HTML()
 {
     # minify all the HTML files
     echo "minifying HTML files with extension $WERCKER_MINIFY_HTML_EXT in $WERCKER_MINIFY_BASE_DIR with arguments $WERCKER_MINIFY_HTML_ARGS"
-    
-    find ${WERCKER_MINIFY_BASE_DIR} -iname "*.${WERCKER_MINIFY_HTML_EXT}" -print0 | xargs -0 -t -P "${WERCKER_MINIFY_THREADS}" -n 1 -I filename html-minifier ${WERCKER_MINIFY_HTML_ARGS} -o filename filename
+
+    find ${WERCKER_MINIFY_BASE_DIR} -iname "*.${WERCKER_MINIFY_HTML_EXT}" -print0 | xargs -0 -t -P "${WERCKER_MINIFY_THREADS}" -n 1 -I filename sh -c '(rm "filename" && html-minifier ${WERCKER_MINIFY_HTML_ARGS} > "filename") < "filename"'
 }
 
 minify_CSS()
 {
     # minify all the CSS files
     echo "minifying CSS files with extension $WERCKER_MINIFY_CSS_EXT in $WERCKER_MINIFY_BASE_DIR with arguments $WERCKER_MINIFY_YUI_ARGS and command $YUI_COMMAND"
-    
+
     find ${WERCKER_MINIFY_BASE_DIR} -iname "*.${WERCKER_MINIFY_CSS_EXT}" -print0 | xargs -0 -t -n 1 -P "${WERCKER_MINIFY_THREADS}" -I filename ${YUI_COMMAND} ${WERCKER_MINIFY_YUI_ARGS} -o filename filename
 }
 
@@ -128,7 +128,7 @@ minify_JS()
 {
     # minify all the JS files
     echo "minifying JS files with extension $WERCKER_MINIFY_JS_EXT in $WERCKER_MINIFY_BASE_DIR with arguments $WERCKER_MINIFY_YUI_ARGS and command $YUI_COMMAND"
-    
+
     find ${WERCKER_MINIFY_BASE_DIR} -iname "*.${WERCKER_MINIFY_JS_EXT}" -print0 | xargs -0 -t -n 1 -P "${WERCKER_MINIFY_THREADS}" -I filename ${YUI_COMMAND} ${WERCKER_MINIFY_YUI_ARGS} -o filename filename
 }
 
@@ -136,7 +136,7 @@ compress_PNG()
 {
     # minify all the PNG files
     echo "minifying PNG files in $WERCKER_MINIFY_BASE_DIR with arguments $WERCKER_MINIFY_PNG_ARGS"
-    
+
     find ${WERCKER_MINIFY_BASE_DIR} -iname "*.png" -print0 | xargs -0 -t -n 1 -P "${WERCKER_MINIFY_THREADS}" optipng ${WERCKER_MINIFY_PNG_ARGS}
 }
 
@@ -146,7 +146,7 @@ verify_java()
     if ! command_exists java; then
         echo "java not installed, installing..."
         update_sources
-        if command_exists apt-get; then      
+        if command_exists apt-get; then
             apt-get install -y openjdk-7-jre
         elif command_exists pacman; then
             pacman -S --noconfirm jre7-openjdk-headless
@@ -162,7 +162,7 @@ verify_curl()
     if ! command_exists curl; then
         echo "curl not installed, installing..."
         update_sources
-        if command_exists apt-get; then       
+        if command_exists apt-get; then
             apt-get install -y curl
         elif command_exists pacman; then
             pacman -S --noconfirm curl
@@ -176,9 +176,9 @@ verify_node()
 {
     # check if node is installed
     if ! command_exists node; then
-    
+
         verify_curl
-    
+
         # install node
         echo "node not installed, installing..."
         if command_exists apt-get; then
@@ -206,9 +206,9 @@ do_PNG()
         else
             yum install -y optipng
         fi
-        
+
     fi
-    
+
     # verify optipng installation
     if ! command_exists html-minifier; then
         echo "optipng installation failed, not compressing PNG"
@@ -226,7 +226,7 @@ do_HTML()
         verify_node
         npm install html-minifier -g
     fi
-    
+
     # verify HTML minifier installation
     if ! command_exists html-minifier; then
         echo "html-minifier installation failed, not minifying HTML"
@@ -239,7 +239,7 @@ do_HTML()
 do_CSS_JS()
 {
     echo "installing yuicompressor..."
-    
+
     if (! command_exists yuicompressor) && (! command_exists yui-compressor); then
         update_sources
         if command_exists apt-get; then
@@ -250,9 +250,9 @@ do_CSS_JS()
             npm install yuicompressor -g
         fi
     fi
-    
+
     verify_YUI
-    
+
     if [ "$WERCKER_MINIFY_CSS" != "false" ]; then
         minify_CSS
     fi
@@ -263,15 +263,15 @@ do_CSS_JS()
 
 if check_branches; then
     set_variables
-    
+
     if [ "$WERCKER_MINIFY_HTML" != "false" ]; then
         do_HTML
     fi
-    
+
     if [ "$WERCKER_MINIFY_CSS" != "false" ] || [ "$WERCKER_MINIFY_JS" != "false" ] ; then
         do_CSS_JS
     fi
-    
+
     if [ "$WERCKER_MINIFY_PNG" != "false" ]; then
         do_PNG
     fi

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -22,7 +22,7 @@ properties:
         required: false
     html_args:
         type: string
-        default: "--use-short-doctype --remove-style-link-type-attributes --remove-script-type-attributes --remove-comments --minify-css --minify-js --collapse-whitespace --remove-comments-from-cdata --conservative-collapse --remove-cdatasections-from-cdata"
+        default: "--use-short-doctype --remove-style-link-type-attributes --remove-script-type-attributes --remove-comments --minify-css --minify-js --collapse-whitespace  --conservative-collapse"
         required: false
     png_args:
         type: string


### PR DESCRIPTION
html-minifier 3.2.3 doesn't make a copy of the source file even if the output file given with -o flag is the same as the source file, and overwrites the source file. As the result of this behavior, html-minifier reads a blank file and outputs nothing. For example, `html-minifier ${WERCKER_MINIFY_HTML_ARGS} -o filename filename` opens `filename` and truncates it to store minified html, and then reads truncated `filename`.

This pull request updates the command running html-minifier to assign a different inode number to the output file, which means the source file and the output file become pointing different inodes and html-minifier doesn't overwrite the source file.

This PR also includes two updates:
- installing Node.js v6.x instead of v0.12,
- deleting deprecated options of html-minifier.
